### PR TITLE
Geojson input cleaning

### DIFF
--- a/notebooks/Colab_whisp_geojson_to_csv.ipynb
+++ b/notebooks/Colab_whisp_geojson_to_csv.ipynb
@@ -188,6 +188,7 @@
       "source": [
         "df_stats = whisp.whisp_formatted_stats_geojson_to_df(\n",
         "    input_geojson_filepath=GEOJSON_EXAMPLE_FILEPATH,\n",
+        "    # external_id_column=\"user_id\",# optional - specify which input column/property to map to the external ID.\n",
         "    national_codes=iso2_codes_list,\n",
         "    # unit_type='percent', # optional - to change unit type. Default is 'ha'. \n",
         "    )"
@@ -359,7 +360,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": ".venv (3.12.0)",
       "language": "python",
       "name": "python3"
     },

--- a/notebooks/whisp_geojson_to_csv.ipynb
+++ b/notebooks/whisp_geojson_to_csv.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "df_formatted_stats = whisp.whisp_formatted_stats_geojson_to_df(\n",
     "    input_geojson_filepath=GEOJSON_EXAMPLE_FILEPATH,\n",
-    "    external_id_column=\"user_id\",# optional - specify which input column/property they want to use as the external ID.\n",
+    "    # external_id_column=\"user_id\", # optional -  specify which input column/property to map to the external ID.\n",
     "    national_codes=iso2_codes_list,  # optional - By default national datasets are not included unless specified here.\n",
     "    # unit_type='percent', # optional - to change unit type. Default is 'ha'. \n",
     ")"

--- a/notebooks/whisp_geojson_to_drive.ipynb
+++ b/notebooks/whisp_geojson_to_drive.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "df_formatted_stats = whisp.whisp_stats_geojson_to_drive(\n",
     "    input_geojson_filepath=GEOJSON_EXAMPLE_FILEPATH,\n",
-    "    external_id_column=\"user_id\",# optional - specify which input column/property they want to use as the external ID.\n",
+    "    # external_id_column=\"user_id\",# optional -  specify which input column/property to map to the external ID.\n",
     "    national_codes=iso2_codes_list,  # optional - By default national datasets are not included unless specified here.\n",
     "    # unit_type='percent', # optional - to change unit type. Default is 'ha'. \n",
     ")"

--- a/src/openforis_whisp/datasets.py
+++ b/src/openforis_whisp/datasets.py
@@ -1264,7 +1264,9 @@ def combine_datasets(national_codes=None):
 
     try:
         # Attempt to print band names to check for errors
-        print(img_combined.bandNames().getInfo())
+        # print(img_combined.bandNames().getInfo())
+        img_combined.bandNames().getInfo()
+
     except ee.EEException as e:
         # logger.error(f"Error printing band names: {e}")
         # logger.info("Running code for filtering to only valid datasets due to error in input")
@@ -1281,6 +1283,7 @@ def combine_datasets(national_codes=None):
             img_combined = img_combined.addBands(img)
 
     img_combined = img_combined.multiply(ee.Image.pixelArea())
+    print("Whisp multiband image compiled")
 
     return img_combined
 


### PR DESCRIPTION
1) bug fix - now has geojson process to strip z values if present; 
2) notebook tidying; 
3) original properties not carried through except external_id_column
This was causing causing logging notifications to be less useful when validating dataframe aghainsst a schema. Now all properties are removed in any case.
 (note that next step is to add an optional parameter to allow other properties beyond the external_id to be carried through if specified)  