### PR TITLE
Update datasets.py to fdap 2025b release

### DIFF
--- a/layers_description.md
+++ b/layers_description.md
@@ -41,13 +41,13 @@ To view the layers in action, go to [https://whisp.earthmap.org/](https://whisp.
     <tr><td>ee.ImageCollection(‘BIOPAMA/GlobalOilPalm/v1’)</td></tr>
     <tr><td rowspan="3">Oil_palm_FDaP</td><td rowspan="3">Palm probability model. Filtered collection to 2020 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/palm/model_2025a")</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/palm/model_2025b")</td></tr>
     <tr><td rowspan="3">Coffee_FDaP</td><td rowspan="3">Coffee probability model. Filtered collection to 2020 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/coffee/model_2025a")</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/coffee/model_2025b")</td></tr>
     <tr><td rowspan="3">Cocoa_FDaP</td><td rowspan="3">Cocoa probability model. Filtered collection to 2020 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/cocoa/model_2025a")</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/cocoa/model_2025b")</td></tr>
     <tr><td rowspan="3">Cocoa_ETH</td><td rowspan="3">Binary product where 1 represents cocoa. Product derived from a cocoa probability map where the recommended threshold of >65%, had already been applied.</td><td rowspan="2">Kalischek, N., Lang, N., Renier, C., Daudt, R. C., Addoah, T., Thompson, W., Blaser-Hart, W. J., Garrett, R., Schindler, K., & Wegner, J. D. (2022). <i>Satellite-based high-resolution maps of cocoa planted area for Côte d’Ivoire and Ghana</i> ( 5). arXiv. https://doi.org/10.48550/ARXIV.2206.06119</td></tr>
     <tr></tr>
     <tr><td>ee.Image(‘projects/ee-nk-cocoa/assets/cocoa_map_threshold_065’)</td></tr>
@@ -60,7 +60,7 @@ Centre d'Information Géographique et du Numérique / Bureau National d'Études 
     <tr><td>ee.Image("users/wangyxtina/MapRubberPaper/rRubber10m202122_perc1585DifESAdist5pxPF")</td>
     <tr><td rowspan="3">Rubber_FDaP</td><td rowspan="3">Rubber probability model. Filtered collection to 2020 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/rubber/model_2025a")</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/rubber/model_2025b")</td></tr>
     <tr><td colspan="3"><b>Annual crops:</b></td></tr>
     <tr><td rowspan="3">Soy_Song_2020</td><td rowspan="3">Soya expansion in South America 2000-2023, binary map for 2020 where 1 is soya.</td><td rowspan="2">Song, X.-P., Hansen, M.C., Potapov, P., Adusei, B., Pickering, J., Adami, M., Lima, A., Zalles, V., Stehman, S.V., Di Bella, C.M., Cecilia, C.M., Copati, E.J., Fernandes, L.B., Hernandez-Serna, A., Jantz,  S.M., Pickens, A.H., Turubanova, S., Tyukavina A. (2021). Massive soybean expansion in South America since 2000 and implications for conservation. Nature Sustainability, 4, 784–792
 https://doi.org/10.1038/s41893-021-00729-z</td></tr>
@@ -144,18 +144,18 @@ https://doi.org/10.1038/s41893-021-00729-z</td></tr>
     <tr><td rowspan="3">ESRI_crop_gain_2023</td><td rowspan="3"> Crop gain in 2023 compared to year 2020 of the ESRI LC map (class 5) </td><td rowspan="2">Karra, Kontgis, et al. “Global land use/land cover with Sentinel-2 and deep learning.”IGARSS 2021-2021 IEEE International Geoscience and Remote Sensing Symposium. IEEE, 2021. </td></tr>
     <tr></tr>
     <tr><td>ee.ImageCollection(“"projects/sat-io/open-datasets/landcover/ESRI_Global-LULC_10m_TS”)</td></tr>
-    <tr><td rowspan="3">Oil_palm_2023_FDaP</td><td rowspan="3"> Palm probability model. Filtered collection to 2023 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership </td></tr>
+    <tr><td rowspan="3">Oil_palm_2024_FDaP</td><td rowspan="3"> Palm probability model. Filtered collection to 2024 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership </td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/palm/model_2025a")</td></tr>
-    <tr><td rowspan="3">Rubber_2023_FDaP</td><td rowspan="3"> Cocoa probability model. Filtered collection to 2023 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy. </td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership </td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/palm/model_2025b")</td></tr>
+    <tr><td rowspan="3">Rubber_2024_FDaP</td><td rowspan="3"> Cocoa probability model. Filtered collection to 2024 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy. </td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership </td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/rubber/model_2025a")</td></tr>
-    <tr><td rowspan="3">Coffee_FDaP_2023</td><td rowspan="3">Coffee probability model. Filtered collection to 2023 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/rubber/model_2025b")</td></tr>
+    <tr><td rowspan="3">Coffee_FDaP_2024</td><td rowspan="3">Coffee probability model. Filtered collection to 2024 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy.</td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/coffee/model_2025a")</td></tr>
-    <tr><td rowspan="3">Cocoa_2023_FDaP</td><td rowspan="3"> Rubber probability model. Filtered collection to 2023 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy. </td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership </td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/coffee/model_2025b")</td></tr>
+    <tr><td rowspan="3">Cocoa_2024_FDaP</td><td rowspan="3"> Rubber probability model. Filtered collection to 2024 data. Threshold set for Whisp based on the intersection of recall and precision in charts for accuracy. </td><td rowspan="2">FDaP (2025). Forest Data Partnership https://developers.google.com/earth-engine/datasets/publisher/forestdatapartnership</td></tr>
     <tr></tr>
-    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/cocoa/model_2025a")</td></tr>
+    <tr><td>ee.ImageCollection("projects/forestdatapartnership/assets/cocoa/model_2025b")</td></tr>
     <tr><td colspan="3"><b>logging concessions:</b></td></tr>
     <tr><td rowspan="3">GFW_logging</td><td rowspan="3"> Logging concessions from GFW (polygon data) </td><td rowspan="2">http://data.globalforestwatch.org/datasets?q=logging </td></tr>
     <tr></tr>

--- a/src/openforis_whisp/datasets.py
+++ b/src/openforis_whisp/datasets.py
@@ -212,113 +212,113 @@ def g_eth_kalischek_cocoa_prep():
 
 # fdap datasets
 
-# Thresholds and model info here https://github.com/google/forest-data-partnership/blob/main/models/README.md
+# Thresholds and model info here https://github.com/google/forest-data-partnership/tree/main/models/model_2025b
 
 # Oil Palm FDaP
 def g_fdap_palm_prep():
     fdap_palm2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/palm/model_2025a"
+        "projects/forestdatapartnership/assets/palm/model_2025b"
     )
     fdap_palm = (
         fdap_palm2020_model_raw.filterDate("2020-01-01", "2020-12-31")
         .mosaic()
-        .gt(0.88)  # Precision and recall ~78% at 0.88 threshold.
+        .gt(0.66)  # Precision and recall ~81% at 0.66 threshold.
     )
     return fdap_palm.rename("Oil_palm_FDaP").selfMask()
 
 
-def g_fdap_palm_2023_prep():
+def g_fdap_palm_2024_prep():
     fdap_palm2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/palm/model_2025a"
+        "projects/forestdatapartnership/assets/palm/model_2025b"
     )
     fdap_palm = (
-        fdap_palm2020_model_raw.filterDate("2023-01-01", "2023-12-31")
+        fdap_palm2020_model_raw.filterDate("2024-01-01", "2024-12-31")
         .mosaic()
-        .gt(0.88)  # Precision and recall ~78% at 0.88 threshold.
+        .gt(0.66)  # recision and recall ~81% at 0.66 threshold.
     )
-    return fdap_palm.rename("Oil_palm_2023_FDaP").selfMask()
+    return fdap_palm.rename("Oil_palm_2024_FDaP").selfMask()
 
 
 # Cocoa FDaP
 def g_fdap_cocoa_prep():
     fdap_cocoa2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/cocoa/model_2025a"
+        "projects/forestdatapartnership/assets/cocoa/model_2025b"
     )
     fdap_cocoa = (
         fdap_cocoa2020_model_raw.filterDate("2020-01-01", "2020-12-31")
         .mosaic()
-        .gt(0.96)  # Precision and recall ~87% 0.96 threshold.
+        .gt(0.5)  # Precision and recall ~94% 0.5 threshold (estimated).
     )
     return fdap_cocoa.rename("Cocoa_FDaP").selfMask()
 
 
-def g_fdap_cocoa_2023_prep():
+def g_fdap_cocoa_2024_prep():
     fdap_cocoa2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/cocoa/model_2025a"
+        "projects/forestdatapartnership/assets/cocoa/model_2025b"
     )
     fdap_cocoa = (
-        fdap_cocoa2020_model_raw.filterDate("2023-01-01", "2023-12-31")
+        fdap_cocoa2020_model_raw.filterDate("2024-01-01", "2024-12-31")
         .mosaic()
-        .gt(0.96)  # Precision and recall ~87% 0.96 threshold.
+        .gt(0.5)  # Precision and recall ~94% 0.5 threshold (estimated).
     )
-    return fdap_cocoa.rename("Cocoa_2023_FDaP").selfMask()
+    return fdap_cocoa.rename("Cocoa_2024_FDaP").selfMask()
 
 
 # Rubber FDaP
 def g_fdap_rubber_prep():
     fdap_rubber2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/rubber/model_2025a"
+        "projects/forestdatapartnership/assets/rubber/model_2025b"
     )
     fdap_rubber = (
         fdap_rubber2020_model_raw.filterDate("2020-01-01", "2020-12-31")
         .mosaic()
-        .gt(0.59)  # Precision and recall ~80% 0.59 threshold.
+        .gt(0.38)  # Precision and recall ~75% 0.38 threshold.
     )
     return fdap_rubber.rename("Rubber_FDaP").selfMask()
 
 
-def g_fdap_rubber_2023_prep():
+def g_fdap_rubber_2024_prep():
     fdap_rubber2020_model_raw = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/rubber/model_2025a"
+        "projects/forestdatapartnership/assets/rubber/model_2025b"
     )
     fdap_rubber = (
-        fdap_rubber2020_model_raw.filterDate("2023-01-01", "2023-12-31")
+        fdap_rubber2020_model_raw.filterDate("2024-01-01", "2024-12-31")
         .mosaic()
-        .gt(0.59)  # Threshold for Rubber
+        .gt(0.38)  # Precision and recall ~75% 0.38 threshold.
     )
-    return fdap_rubber.rename("Rubber_2023_FDaP").selfMask()
+    return fdap_rubber.rename("Rubber_2024_FDaP").selfMask()
 
 
 # # Coffee FDaP
 def g_fdap_coffee_2020_prep():
     # Load the coffee model for 2020
     collection = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/coffee/model_2025a"
+        "projects/forestdatapartnership/assets/coffee/model_2025b"
     )
 
     # Filter the collection for the year 2020 and create a binary mask
     coffee_2020 = (
         collection.filterDate("2020-01-01", "2020-12-31")
         .mosaic()
-        .gt(0.99)  # Precision and recall ~54% 0.99 threshold.
+        .gt(0.28)  # Precision and recall ~70% 0.28 threshold.
     )
 
     return coffee_2020.rename("Coffee_FDaP").selfMask()
 
 
-def g_fdap_coffee_2023_prep():
+def g_fdap_coffee_2024_prep():
     # Load the coffee model for 2020
     collection = ee.ImageCollection(
-        "projects/forestdatapartnership/assets/coffee/model_2025a"
+        "projects/forestdatapartnership/assets/coffee/model_2025b"
     )
 
     # Filter the collection for the year 2023 and create a binary mask
-    coffee_2023 = (
-        collection.filterDate("2023-01-01", "2023-12-31")
+    coffee_2024 = (
+        collection.filterDate("2024-01-01", "2024-12-31")
         .mosaic()
-        .gt(0.99)  # Precision and recall ~54% 0.99 threshold.
+        .gt(0.28)  # Precision and recall ~70% 0.28 threshold.
     )
-    return coffee_2023.rename("Coffee_FDaP_2023").selfMask()
+    return coffee_2024.rename("Coffee_FDaP_2024").selfMask()
 
 
 # Rubber_RBGE  - from Royal Botanical Gardens of Edinburgh (RBGE) NB for 2021

--- a/src/openforis_whisp/parameters/lookup_gee_datasets.csv
+++ b/src/openforis_whisp/parameters/lookup_gee_datasets.csv
@@ -186,10 +186,10 @@ GFT_planted_plantation,1840,,NA,planted_plantation_2020,0,1,0,float32,1,0,g_gft_
 IIASA_planted_plantation,1850,,NA,planted_plantation_2020,0,1,0,float32,1,0,g_iiasa_planted_prep
 TMF_regrowth_2023,1860,,NA,treecover_after_2020,0,1,0,float32,1,0,g_tmf_regrowth_prep
 ESRI_2023_TC,1870,,NA,treecover_after_2020,0,1,0,float32,1,0,g_esri_2023_tc_prep
-Oil_palm_2023_FDaP,1880,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_palm_2023_prep
-Rubber_2023_FDaP,1890,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_rubber_2023_prep
-Coffee_FDaP_2023,1900,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_coffee_2023_prep
-Cocoa_2023_FDaP,1910,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_cocoa_2023_prep
+Oil_palm_2024_FDaP,1880,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_palm_2024_prep
+Rubber_2024_FDaP,1890,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_rubber_2024_prep
+Coffee_FDaP_2024,1900,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_coffee_2024_prep
+Cocoa_2024_FDaP,1910,,NA,agri_after_2020,0,1,0,float32,1,0,g_fdap_cocoa_2024_prep
 ESRI_crop_gain_2020_2023,1920,,NA,agri_after_2020,0,1,0,float32,1,0,g_esri_2020_2023_crop_prep
 GFW_logging_before_2020,1930,,NA,logging_concession,0,1,0,float32,1,0,g_logging_concessions_prep
 nCO_ideam_forest_2020,1940,CO,treecover,NA,1,1,0,float32,1,0,nco_ideam_forest_2020_prep


### PR DESCRIPTION
Update collection links to point to 2025b release.  Update thresholds accordingly.  Change the 2023 filters to 2024 and rename accordingly.