### PR TITLE
Add MODIS_fire_2026 to the LUT (band was generated then silently dropped)

### DIFF
--- a/src/openforis_whisp/parameters/lookup_gee_datasets.csv
+++ b/src/openforis_whisp/parameters/lookup_gee_datasets.csv
@@ -163,6 +163,7 @@ MODIS_fire_2022,1620,,disturbance_after,NA,0,0,0,float32,1,0,g_modis_fire_prep
 MODIS_fire_2023,1630,,disturbance_after,NA,0,0,0,float32,1,0,g_modis_fire_prep
 MODIS_fire_2024,1640,,disturbance_after,NA,0,0,0,float32,1,0,g_modis_fire_prep
 MODIS_fire_2025,1650,,disturbance_after,NA,0,0,0,float32,1,0,g_modis_fire_prep
+MODIS_fire_2026,1655,,disturbance_after,NA,0,0,0,float32,1,0,g_modis_fire_prep
 TMF_deg_before_2020,1660,,disturbance_before,NA,1,1,0,float32,1,0,g_tmf_deg_before_2020_prep
 TMF_def_before_2020,1670,,disturbance_before,NA,1,1,0,float32,1,0,g_tmf_def_before_2020_prep
 GFC_loss_before_2020,1680,,disturbance_before,NA,1,1,0,float32,1,0,g_glad_gfc_loss_before_2020_prep


### PR DESCRIPTION
g_modis_fire_prep now generates a MODIS_fire_2026 band (MCD64A1 has 2026 imagery, latest image 2026-03-01), but with no matching LUT row it was being dropped during schema validation, so the 2026 MODIS fire data never reached the output. Adds the row mirroring MODIS_fire_2025.

See #206 (warn instead of silently dropping unlisted bands) and #203 (generate these per-year rows dynamically).