### PR TITLE
Fix Ind_02_commodities always empty (inverted dedup); activate venv in run_pytest.sh

### DIFF
--- a/src/openforis_whisp/risk.py
+++ b/src/openforis_whisp/risk.py
@@ -73,6 +73,12 @@ def detect_unit_type(df, explicit_unit_type=None):
     return unit_type
 
 
+def _dedupe_keep_order(items: list) -> list:
+    """Return items with duplicates removed, preserving first-seen order."""
+    seen: set = set()
+    return [x for x in items if not (x in seen or seen.add(x))]
+
+
 # Update whisp_risk to accept and pass the unit_type parameter
 def whisp_risk(
     df: data_lookup_type,  # CHECK THIS
@@ -211,10 +217,7 @@ def whisp_risk(
         _acrop_cols = get_cols_ind_02_commodities(
             filtered_lookup_gee_datasets_df, risk_col="use_for_risk_acrop"
         )
-        _seen: set = set()
-        ind_2_input_columns = [
-            c for c in _pcrop_cols + _acrop_cols if not (_seen.add(c) or c in _seen)
-        ]
+        ind_2_input_columns = _dedupe_keep_order(_pcrop_cols + _acrop_cols)
     if ind_3_input_columns is None:
         ind_3_input_columns = get_cols_ind_03_dist_before_2020(
             filtered_lookup_gee_datasets_df
@@ -739,10 +742,7 @@ def get_cols_ind_08_planted_after_2020(lookup_gee_datasets_df):
     Returns:
     list: List of dataset names set to be used in the risk calculations for the degradation - planted and plantation forests post 2020, excluding those marked for exclusion.
     """
-    # NOTE: no dataset currently feeds Ind_08, so this returns [] and the indicator does
-    # not fire (see #195). FDaP palm/rubber change signal is hard to trust; TMF
-    # forest->plantation (TransitionMap_Subtypes 81-86) seems limited in scope globally.
-    # Needs more investigation before wiring a source in.
+    # No dataset currently feeds Ind_08, so this returns [] and the indicator does not fire (see #195).
     lookup_gee_datasets_df = lookup_gee_datasets_df[
         lookup_gee_datasets_df["exclude_from_output"] != 1
     ]

--- a/tests/helpers/test_risk_helpers.py
+++ b/tests/helpers/test_risk_helpers.py
@@ -1,0 +1,25 @@
+from openforis_whisp.risk import (
+    _dedupe_keep_order,
+    get_cols_ind_02_commodities,
+    lookup_gee_datasets_df,
+)
+
+
+def test_dedupe_keep_order():
+    assert _dedupe_keep_order(["a", "b", "b", "c", "a"]) == ["a", "b", "c"]
+    assert _dedupe_keep_order([]) == []
+
+
+def test_ind_02_commodity_union_not_empty():
+    # Regression guard: an inverted dedup once made the Ind_02_commodities union
+    # always empty, so commodities never fired. The union of the perennial and
+    # annual commodity datasets must be non-empty and keep every unique dataset.
+    pcrop = get_cols_ind_02_commodities(
+        lookup_gee_datasets_df, risk_col="use_for_risk_pcrop"
+    )
+    acrop = get_cols_ind_02_commodities(
+        lookup_gee_datasets_df, risk_col="use_for_risk_acrop"
+    )
+    union = _dedupe_keep_order(pcrop + acrop)
+    assert len(union) > 0
+    assert len(union) == len(set(pcrop + acrop))


### PR DESCRIPTION
Commodities weren't firing at all in the risk trees. Ind_02 (the commodity indicator) is built by combining the perennial and annual commodity lists and de-duplicating them, but the dedup was written back-to-front, `not (seen.add(c) or c in seen)`: it adds each item before checking whether it's already there, so it drops everything. Ind_02 ends up empty and no commodity ever counts, across pcrop, acrop, cattle and the timber agriculture branch.

This came in with the lookup-table merge (#217), so it's on main but not in any released version (a14 and earlier predate #217, which is why the published package still detects commodities).

Pull the dedup into a small _dedupe_keep_order helper and add a test that the commodity union isn't empty.
Drop the old FDaP/TMF notes from the Ind_08 getter, they described datasets not relevant to that indicator.