### PR TITLE
Add split_multipart_geojson for splitting multipart geometries

### DIFF
--- a/src/openforis_whisp/__init__.py
+++ b/src/openforis_whisp/__init__.py
@@ -100,6 +100,7 @@ from openforis_whisp.data_conversion import (
     convert_csv_to_geojson,
     convert_ee_to_geojson,
     normalize_geojson_to_gdf,
+    split_multipart_geojson,
 )
 
 from openforis_whisp.risk import whisp_risk, detect_unit_type

--- a/src/openforis_whisp/data_checks.py
+++ b/src/openforis_whisp/data_checks.py
@@ -88,13 +88,16 @@ def analyze_geojson(
         - Path: pathlib.Path to GeoJSON file
     metrics : list
         Which metrics to return. Available metrics:
-        - 'count': number of polygons
+        - 'count': number of features (split multipart geometries beforehand so this
+          equals the number of single-part rows to be processed)
         - 'geometry_types': dict of geometry type counts (e.g., {'Polygon': 95, 'MultiPolygon': 5})
         - 'crs': coordinate reference system (e.g., 'EPSG:4326') - only available when geojson_data is a file path
         - 'file_size_mb': file size in megabytes (only available when geojson_data is a file path)
-        - 'min_area_ha', 'mean_area_ha', 'median_area_ha', 'max_area_ha': area statistics (hectares) (accurate only at equator)
+        - 'min_area_ha', 'mean_area_ha', 'median_area_ha', 'max_area_ha': per-feature area
+          statistics (hectares; a MultiPolygon counts once, summed; accurate only at equator)
         - 'area_percentiles': dict with p25, p50 (median), p75, p90 area values (accurate only at equator)
-        - 'min_vertices', 'mean_vertices', 'median_vertices', 'max_vertices': vertex count statistics
+        - 'min_vertices', 'mean_vertices', 'median_vertices', 'max_vertices': per-feature
+          vertex-count statistics (a MultiPolygon counts once, summed over its parts)
         - 'vertex_percentiles': dict with p25, p50 (median), p75, p90 vertex count values
 
         Default includes all metrics for comprehensive analysis.
@@ -106,19 +109,23 @@ def analyze_geojson(
     Returns:
     --------
     dict with requested metrics:
-        - 'count': number of polygons
+        - 'count': number of features
+        - 'geometrycollection_warning': present only if GeometryCollection features are found
         - 'geometry_types': {'Polygon': int, 'MultiPolygon': int, ...}
         - 'crs': coordinate reference system string (e.g., 'EPSG:4326', only when geojson_data is a file path)
         - 'file_size_mb': file size in megabytes (float, only when geojson_data is a file path)
-        - 'min_area_ha': minimum area among all polygons in hectares
-        - 'mean_area_ha': mean area per polygon in hectares (calculated from coordinates)
-        - 'median_area_ha': median area among all polygons in hectares
-        - 'max_area_ha': maximum area among all polygons in hectares
+        (area/vertex stats below are per-feature: a MultiPolygon counts once, summed
+         over its parts. Split multipart geometries beforehand if you want per-part
+         stats and a 'count' equal to the number of rows to be processed.)
+        - 'min_area_ha': minimum per-feature area in hectares
+        - 'mean_area_ha': mean per-feature area in hectares
+        - 'median_area_ha': median per-feature area in hectares
+        - 'max_area_ha': maximum per-feature area in hectares
         - 'area_percentiles': {'p25': float, 'p50': float, 'p75': float, 'p90': float}
-        - 'min_vertices': minimum number of vertices among all polygons
-        - 'mean_vertices': mean number of vertices per polygon
-        - 'median_vertices': median number of vertices among all polygons
-        - 'max_vertices': maximum number of vertices among all polygons
+        - 'min_vertices': minimum per-feature vertex count
+        - 'mean_vertices': mean per-feature vertex count
+        - 'median_vertices': median per-feature vertex count
+        - 'max_vertices': maximum per-feature vertex count
         - 'vertex_percentiles': {'p25': int, 'p50': int, 'p75': int, 'p90': int}
     """
     # Handle None metrics (use all default metrics)
@@ -176,7 +183,7 @@ def analyze_geojson(
 
                     # Check if CRS is WGS84
                     if detected_crs and detected_crs != "EPSG:4326":
-                        crs_warning = f"⚠️  CRS is {detected_crs}, not EPSG:4326. Area metrics will be inaccurate. Data will be auto-reprojected during processing."
+                        crs_warning = f"Warning: CRS is {detected_crs}, not EPSG:4326. Area metrics will be inaccurate. Data will be auto-reprojected during processing."
                 except Exception as e:
                     # If fiona fails, assume WGS84 (GeoJSON default)
                     detected_crs = "EPSG:4326"
@@ -247,99 +254,139 @@ def analyze_geojson(
             geometry_type_counts = {}
             valid_polygons = 0
 
-            # Detect CRS to determine area conversion factor
+            # Area/vertex computation (shapely) is the expensive part of the sweep.
+            # Only do it when the caller asked for those metrics, so cheap checks
+            # (count, geometry_types) stay ~1 ms instead of ~250 ms.
+            need_area = any(
+                m in metrics
+                for m in [
+                    "min_area_ha",
+                    "mean_area_ha",
+                    "median_area_ha",
+                    "max_area_ha",
+                    "area_percentiles",
+                ]
+            )
+            need_vertices = any(
+                m in metrics
+                for m in [
+                    "min_vertices",
+                    "mean_vertices",
+                    "median_vertices",
+                    "max_vertices",
+                    "vertex_percentiles",
+                ]
+            )
+
+            # Detect CRS to determine area conversion factor (only needed for area)
             area_conversion_factor = 1232100  # Default: WGS84 (degrees to ha)
             detected_crs = None
 
             # Try to detect CRS from file if available
-            if file_path:
+            if need_area and file_path:
                 try:
                     import geopandas as gpd
 
                     gdf_temp = gpd.read_file(str(file_path))
                     detected_crs = gdf_temp.crs
                     if detected_crs and detected_crs != "EPSG:4326":
-                        # Projected CRS typically uses meters, so convert m² to ha
-                        # 1 ha = 10,000 m²
+                        # Projected CRS typically uses meters, so convert m^2 to ha
+                        # 1 ha = 10,000 m^2
                         area_conversion_factor = 1 / 10000
                 except Exception:
                     pass  # Use default if CRS detection fails
 
             for feature in features:
                 try:
-                    coords = feature["geometry"]["coordinates"]
-                    geom_type = feature["geometry"]["type"]
-                    properties = feature.get("properties", {})
+                    geometry = feature.get("geometry") or {}
+                    geom_type = geometry.get("type")
+                    if geom_type is None:
+                        continue
 
-                    # Count geometry types
+                    # Count geometry types first (all types, including unsupported
+                    # ones like GeometryCollection) so nothing is silently dropped
                     geometry_type_counts[geom_type] = (
                         geometry_type_counts.get(geom_type, 0) + 1
                     )
 
-                    if geom_type == "Polygon":
-                        # Count vertices in this polygon
-                        feature_vertices = 0
-                        for ring in coords:
-                            feature_vertices += len(ring)
-                        vertices_list.append(feature_vertices)
+                    # GeometryCollection is not a standard Whisp plot type and has no
+                    # top-level "coordinates"; it is counted above, then excluded from
+                    # area/vertex stats (flagged after the loop).
+                    if geom_type == "GeometryCollection":
+                        continue
 
-                        # Calculate area from coordinates using shapely
-                        try:
-                            # Use shapely.geometry.shape to properly handle all geometry components
-                            geom = shapely_shape(feature["geometry"])
-                            # Convert using detected CRS
-                            area_ha = abs(geom.area) * area_conversion_factor
-                            areas.append(area_ha)
-                        except Exception as e:
-                            # Fallback: estimate from bounding box if geometry fails
-                            bbox_area = _estimate_area_from_bounds(
-                                coords, area_conversion_factor
-                            )
-                            if bbox_area > 0:
-                                areas.append(bbox_area)
-                                bbox_fallback_count += 1
-                                polygon_type_stats["Polygon_bbox"] = (
-                                    polygon_type_stats.get("Polygon_bbox", 0) + 1
+                    coords = geometry["coordinates"]
+                    properties = feature.get("properties", {})
+
+                    if geom_type == "Polygon":
+                        # Count vertices only if a vertex metric was requested
+                        if need_vertices:
+                            feature_vertices = 0
+                            for ring in coords:
+                                feature_vertices += len(ring)
+                            vertices_list.append(feature_vertices)
+
+                        # Calculate area only if an area metric was requested
+                        # (shapely is the expensive part of the sweep)
+                        if need_area:
+                            try:
+                                geom = shapely_shape(feature["geometry"])
+                                area_ha = abs(geom.area) * area_conversion_factor
+                                areas.append(area_ha)
+                            except Exception as e:
+                                # Fallback: estimate from bounding box if geometry fails
+                                bbox_area = _estimate_area_from_bounds(
+                                    coords, area_conversion_factor
                                 )
-                            else:
-                                geometry_skip_count += 1
-                                polygon_type_stats["Polygon_skipped"] = (
-                                    polygon_type_stats.get("Polygon_skipped", 0) + 1
-                                )
+                                if bbox_area > 0:
+                                    areas.append(bbox_area)
+                                    bbox_fallback_count += 1
+                                    polygon_type_stats["Polygon_bbox"] = (
+                                        polygon_type_stats.get("Polygon_bbox", 0) + 1
+                                    )
+                                else:
+                                    geometry_skip_count += 1
+                                    polygon_type_stats["Polygon_skipped"] = (
+                                        polygon_type_stats.get("Polygon_skipped", 0) + 1
+                                    )
                         valid_polygons += 1
 
                     elif geom_type == "MultiPolygon":
-                        # Count vertices in this multipolygon
-                        feature_vertices = 0
-                        for polygon in coords:
-                            for ring in polygon:
-                                feature_vertices += len(ring)
-                        vertices_list.append(feature_vertices)
+                        # Per-feature (one summed entry per MultiPolygon). This is a
+                        # fast check; the real per-part split is done separately by
+                        # exploding the GeoJSON before processing.
+                        if need_vertices:
+                            feature_vertices = 0
+                            for polygon in coords:
+                                for ring in polygon:
+                                    feature_vertices += len(ring)
+                            vertices_list.append(feature_vertices)
 
-                        # Calculate area from coordinates using shapely
-                        try:
-                            # Use shapely.geometry.shape to properly handle MultiPolygon
-                            geom = shapely_shape(feature["geometry"])
-                            # Convert using detected CRS - use total area of all parts
-                            area_ha = abs(geom.area) * area_conversion_factor
-                            areas.append(area_ha)
-                        except Exception as e:
-                            # Fallback: estimate from bounding box if geometry fails
-                            bbox_area = _estimate_area_from_bounds(
-                                coords, area_conversion_factor
-                            )
-                            if bbox_area > 0:
-                                areas.append(bbox_area)
-                                bbox_fallback_count += 1
-                                polygon_type_stats["MultiPolygon_bbox"] = (
-                                    polygon_type_stats.get("MultiPolygon_bbox", 0) + 1
+                        if need_area:
+                            try:
+                                geom = shapely_shape(feature["geometry"])
+                                area_ha = abs(geom.area) * area_conversion_factor
+                                areas.append(area_ha)
+                            except Exception as e:
+                                # Fallback: estimate from bounding box if geometry fails
+                                bbox_area = _estimate_area_from_bounds(
+                                    coords, area_conversion_factor
                                 )
-                            else:
-                                geometry_skip_count += 1
-                                polygon_type_stats["MultiPolygon_skipped"] = (
-                                    polygon_type_stats.get("MultiPolygon_skipped", 0)
-                                    + 1
-                                )
+                                if bbox_area > 0:
+                                    areas.append(bbox_area)
+                                    bbox_fallback_count += 1
+                                    polygon_type_stats["MultiPolygon_bbox"] = (
+                                        polygon_type_stats.get("MultiPolygon_bbox", 0)
+                                        + 1
+                                    )
+                                else:
+                                    geometry_skip_count += 1
+                                    polygon_type_stats["MultiPolygon_skipped"] = (
+                                        polygon_type_stats.get(
+                                            "MultiPolygon_skipped", 0
+                                        )
+                                        + 1
+                                    )
                         valid_polygons += 1
 
                 except:
@@ -350,6 +397,19 @@ def analyze_geojson(
             # Geometry type counts
             if "geometry_types" in metrics:
                 results["geometry_types"] = geometry_type_counts
+
+            # Flag GeometryCollection features: valid GeoJSON but not a standard Whisp
+            # plot type (expected Polygon/MultiPolygon). They are excluded from the
+            # area/vertex statistics above, so warn rather than drop them silently.
+            gc_count = geometry_type_counts.get("GeometryCollection", 0)
+            if gc_count:
+                gc_warning = (
+                    f"Warning: {gc_count} GeometryCollection feature(s) detected. These are not a "
+                    f"standard Whisp plot type (expected Polygon/MultiPolygon) and are excluded "
+                    f"from area and vertex statistics; review or pre-clean the input before processing."
+                )
+                results["geometrycollection_warning"] = gc_warning
+                print(gc_warning)
 
             if areas or vertices_list:
                 # Area statistics
@@ -657,7 +717,8 @@ def check_geojson_limits(
             'max_area_ha': float,
             'mean_vertices': float,
             'max_vertices': int,
-            'valid': bool
+            'valid': bool,
+            'geometrycollection_warning': str  # only if GeometryCollection features found
         }
 
     Raises:
@@ -725,6 +786,10 @@ def check_geojson_limits(
         "crs": metrics.get("crs"),
         "valid": True,
     }
+
+    # Propagate the GeometryCollection warning (advisory; does not fail the check)
+    if metrics.get("geometrycollection_warning"):
+        results["geometrycollection_warning"] = metrics["geometrycollection_warning"]
 
     if verbose:
         print("\nComputed Metrics:")

--- a/src/openforis_whisp/data_checks.py
+++ b/src/openforis_whisp/data_checks.py
@@ -88,16 +88,13 @@ def analyze_geojson(
         - Path: pathlib.Path to GeoJSON file
     metrics : list
         Which metrics to return. Available metrics:
-        - 'count': number of features (split multipart geometries beforehand so this
-          equals the number of single-part rows to be processed)
+        - 'count': number of polygons
         - 'geometry_types': dict of geometry type counts (e.g., {'Polygon': 95, 'MultiPolygon': 5})
         - 'crs': coordinate reference system (e.g., 'EPSG:4326') - only available when geojson_data is a file path
         - 'file_size_mb': file size in megabytes (only available when geojson_data is a file path)
-        - 'min_area_ha', 'mean_area_ha', 'median_area_ha', 'max_area_ha': per-feature area
-          statistics (hectares; a MultiPolygon counts once, summed; accurate only at equator)
+        - 'min_area_ha', 'mean_area_ha', 'median_area_ha', 'max_area_ha': area statistics (hectares) (accurate only at equator)
         - 'area_percentiles': dict with p25, p50 (median), p75, p90 area values (accurate only at equator)
-        - 'min_vertices', 'mean_vertices', 'median_vertices', 'max_vertices': per-feature
-          vertex-count statistics (a MultiPolygon counts once, summed over its parts)
+        - 'min_vertices', 'mean_vertices', 'median_vertices', 'max_vertices': vertex count statistics
         - 'vertex_percentiles': dict with p25, p50 (median), p75, p90 vertex count values
 
         Default includes all metrics for comprehensive analysis.
@@ -109,23 +106,20 @@ def analyze_geojson(
     Returns:
     --------
     dict with requested metrics:
-        - 'count': number of features
+        - 'count': number of polygons
         - 'geometrycollection_warning': present only if GeometryCollection features are found
         - 'geometry_types': {'Polygon': int, 'MultiPolygon': int, ...}
         - 'crs': coordinate reference system string (e.g., 'EPSG:4326', only when geojson_data is a file path)
         - 'file_size_mb': file size in megabytes (float, only when geojson_data is a file path)
-        (area/vertex stats below are per-feature: a MultiPolygon counts once, summed
-         over its parts. Split multipart geometries beforehand if you want per-part
-         stats and a 'count' equal to the number of rows to be processed.)
-        - 'min_area_ha': minimum per-feature area in hectares
-        - 'mean_area_ha': mean per-feature area in hectares
-        - 'median_area_ha': median per-feature area in hectares
-        - 'max_area_ha': maximum per-feature area in hectares
+        - 'min_area_ha': minimum area among all polygons in hectares
+        - 'mean_area_ha': mean area per polygon in hectares (calculated from coordinates)
+        - 'median_area_ha': median area among all polygons in hectares
+        - 'max_area_ha': maximum area among all polygons in hectares
         - 'area_percentiles': {'p25': float, 'p50': float, 'p75': float, 'p90': float}
-        - 'min_vertices': minimum per-feature vertex count
-        - 'mean_vertices': mean per-feature vertex count
-        - 'median_vertices': median per-feature vertex count
-        - 'max_vertices': maximum per-feature vertex count
+        - 'min_vertices': minimum number of vertices among all polygons
+        - 'mean_vertices': mean number of vertices per polygon
+        - 'median_vertices': median number of vertices among all polygons
+        - 'max_vertices': maximum number of vertices among all polygons
         - 'vertex_percentiles': {'p25': int, 'p50': int, 'p75': int, 'p90': int}
     """
     # Handle None metrics (use all default metrics)

--- a/src/openforis_whisp/data_conversion.py
+++ b/src/openforis_whisp/data_conversion.py
@@ -281,6 +281,13 @@ def split_multipart_geojson(
     (i.e. the whisp-app ``count_individual_polygons`` value), so a separate polygon
     count is no longer needed.
 
+    Note on the geometry audit trail: this runs before the stats call, so with
+    ``geometry_audit_trail=True`` the ``geo_original`` column holds each split single
+    part in 2D, not the original MultiPolygon and not its Z values (both are dropped
+    here). Always feed the split geojson into the stats call so ``geo_original`` lines
+    up with the results. To trace a part back to the geometry the user submitted, use
+    ``external_id``: all parts of one input share it.
+
     Parameters
     ----------
     geojson_data : str | Path | dict

--- a/src/openforis_whisp/data_conversion.py
+++ b/src/openforis_whisp/data_conversion.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List, Any, Union
 from geojson import Feature, FeatureCollection, Polygon, Point
 import json
+import logging
 import os
 import geopandas as gpd
 import ee
@@ -145,6 +146,200 @@ def normalize_geojson_to_gdf(
         gdf[id_column] = range(1, len(gdf) + 1)
 
     return gdf
+
+
+def _strip_z(coord: list) -> list:
+    """Drop any Z (and higher) ordinate, keeping [lon, lat]."""
+    return coord[:2]
+
+
+def _split_geometry_into_features(
+    node: Any,
+    out: List[dict],
+    properties: dict,
+    counters: dict,
+    add_part_index: bool,
+) -> None:
+    """
+    Recursively extract single-part features from any GeoJSON node.
+
+    Mirrors the historic whisp-app ``extractFeatures``: MultiPolygon / MultiPoint are
+    split into single parts, GeometryCollection is decomposed, Feature and
+    FeatureCollection are unwrapped, and Z coordinates are stripped. Properties
+    (including external_id) propagate to every emitted feature.
+    """
+    if not isinstance(node, dict):
+        return
+    t = node.get("type")
+
+    if t == "Polygon":
+        out.append(
+            {
+                "type": "Feature",
+                "properties": {**properties},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [_strip_z(c) for c in ring]
+                        for ring in (node.get("coordinates") or [])
+                    ],
+                },
+            }
+        )
+    elif t == "Point":
+        out.append(
+            {
+                "type": "Feature",
+                "properties": {**properties},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": _strip_z(node.get("coordinates") or []),
+                },
+            }
+        )
+    elif t == "MultiPoint":
+        counters["multipart"] += 1
+        for idx, pt in enumerate(node.get("coordinates") or [], start=1):
+            props = {**properties}
+            if add_part_index:
+                props["part_index"] = idx
+            out.append(
+                {
+                    "type": "Feature",
+                    "properties": props,
+                    "geometry": {"type": "Point", "coordinates": _strip_z(pt or [])},
+                }
+            )
+    elif t == "MultiPolygon":
+        counters["multipart"] += 1
+        for idx, poly in enumerate(node.get("coordinates") or [], start=1):
+            props = {**properties}
+            if add_part_index:
+                props["part_index"] = idx
+            out.append(
+                {
+                    "type": "Feature",
+                    "properties": props,
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [_strip_z(c) for c in ring] for ring in (poly or [])
+                        ],
+                    },
+                }
+            )
+    elif t == "GeometryCollection":
+        counters["geometrycollection"] += 1
+        for sub in node.get("geometries") or []:
+            _split_geometry_into_features(
+                sub, out, properties, counters, add_part_index
+            )
+    elif t == "Feature":
+        _split_geometry_into_features(
+            node.get("geometry") or {},
+            out,
+            node.get("properties") or {},
+            counters,
+            add_part_index,
+        )
+    elif t == "FeatureCollection":
+        for feat in node.get("features") or []:
+            _split_geometry_into_features(feat, out, {}, counters, add_part_index)
+    # Other geometry types (LineString, MultiLineString) are not Whisp plot types and
+    # are dropped, matching the historic whisp-app behavior.
+
+
+def split_multipart_geojson(
+    geojson_data: Union[str, Path, dict],
+    logger: logging.Logger = None,
+    add_part_index: bool = False,
+) -> dict:
+    """
+    Split multipart geometries into single-part features, in pure Python.
+
+    A self-contained reproduction of the historic whisp-app ``extractFeatures``
+    normalisation, done as a plain dict transform (no geopandas or shapely, roughly
+    30x faster than building a GeoDataFrame and calling ``explode()``):
+
+    - MultiPolygon        -> one Polygon feature per part
+    - MultiPoint          -> one Point feature per part
+    - GeometryCollection  -> decomposed into its constituent geometries
+    - Feature / FeatureCollection -> unwrapped
+    - Z (and higher) coordinates are stripped, keeping [lon, lat]
+    - other geometry types (LineString, MultiLineString) are dropped, as they are not
+      Whisp plot types (matching the historic behavior)
+
+    Every emitted feature inherits all of its parent's properties, so a feature
+    carrying an ``external_id`` becomes N features that all share that same
+    ``external_id``. This matches the documented Whisp contract that "any multipolygons
+    in the input will be split into individual parts, which may result in duplicate
+    attribute values in the output" - the parts are attribute-identical by design.
+
+    Intended to run BEFORE analyze_geojson / check_geojson_limits and before the stats
+    pathway, so everything downstream sees only single-part geometries. After this
+    step ``analyze_geojson(fc)["count"]`` equals the number of individual polygons
+    (i.e. the whisp-app ``count_individual_polygons`` value), so a separate polygon
+    count is no longer needed.
+
+    Parameters
+    ----------
+    geojson_data : str | Path | dict
+        A GeoJSON FeatureCollection / Feature / geometry dict, or a path to a GeoJSON file.
+    logger : logging.Logger, optional
+        Logger for the user-facing feedback. Defaults to the shared 'whisp' logger.
+    add_part_index : bool
+        If True, add a 1-based 'part_index' property to each split part for
+        traceability. Defaults to False to keep parts attribute-identical (matching
+        the historic whisp-app behavior, which adds no such column).
+
+    Returns
+    -------
+    dict
+        A GeoJSON FeatureCollection containing only single-part geometries.
+    """
+    logger = logger or logging.getLogger("whisp")
+
+    # Load from file if a path was given
+    if isinstance(geojson_data, (str, Path)):
+        with open(geojson_data, "r", encoding="utf-8") as f:
+            geojson_data = json.load(f)
+
+    if (
+        isinstance(geojson_data, dict)
+        and geojson_data.get("type") == "FeatureCollection"
+    ):
+        n_in = len(geojson_data.get("features") or [])
+    else:
+        n_in = 1
+
+    out_features: List[dict] = []
+    counters = {"multipart": 0, "geometrycollection": 0}
+    _split_geometry_into_features(
+        geojson_data, out_features, {}, counters, add_part_index
+    )
+
+    n_out = len(out_features)
+    n_multipart = counters["multipart"]
+    n_gc = counters["geometrycollection"]
+
+    # User-facing feedback
+    if n_multipart or n_gc:
+        parts = []
+        if n_multipart:
+            parts.append(
+                f"{n_multipart:,} multipart geometr"
+                f"{'y' if n_multipart == 1 else 'ies'} split into single parts"
+            )
+        if n_gc:
+            parts.append(f"{n_gc:,} GeometryCollection decomposed")
+        logger.info(
+            f"{n_in:,} feature(s) received; {'; '.join(parts)}; "
+            f"processing {n_out:,} single-part feature(s). external_id preserved on every part."
+        )
+    else:
+        logger.debug(f"{n_in:,} feature(s); no multipart geometries to split")
+
+    return {"type": "FeatureCollection", "features": out_features}
 
 
 def _create_ee_feature_collection(

--- a/tests/helpers/test_split_multipart.py
+++ b/tests/helpers/test_split_multipart.py
@@ -1,0 +1,179 @@
+"""Tests for split_multipart_geojson and the analyze_geojson geometry changes."""
+
+from __future__ import annotations
+
+from openforis_whisp.data_conversion import split_multipart_geojson
+from openforis_whisp.data_checks import analyze_geojson
+
+
+def _square(ox, oy, z=None):
+    """A closed unit-square ring at offset (ox, oy), optionally 3D."""
+    pts = [(ox, oy), (ox, oy + 1), (ox + 1, oy + 1), (ox + 1, oy), (ox, oy)]
+    if z is None:
+        return [[list(p) for p in pts]]
+    return [[[x, y, z] for (x, y) in pts]]
+
+
+# ---------------------------------------------------------------------------
+# split_multipart_geojson
+# ---------------------------------------------------------------------------
+
+
+def test_multipolygon_split_duplicates_external_id_with_no_part_index():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"external_id": "A", "crop": "cocoa"},
+                "geometry": {"type": "Polygon", "coordinates": _square(0, 0)},
+            },
+            {
+                "type": "Feature",
+                "properties": {"external_id": "B", "crop": "coffee"},
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [_square(2, 2), _square(4, 4), _square(6, 6)],
+                },
+            },
+        ],
+    }
+    out = split_multipart_geojson(fc)
+    feats = out["features"]
+
+    # Polygon A stays 1, MultiPolygon B becomes 3 -> 4 single-part features
+    assert len(feats) == 4
+    b_parts = [f for f in feats if f["properties"]["external_id"] == "B"]
+    assert len(b_parts) == 3
+    assert all(f["geometry"]["type"] == "Polygon" for f in b_parts)
+    # Attributes are duplicated identically, with no disambiguating part_index
+    assert all(
+        f["properties"] == {"external_id": "B", "crop": "coffee"} for f in b_parts
+    )
+
+
+def test_geometrycollection_is_decomposed_recursively():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"external_id": "C"},
+                "geometry": {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "Polygon", "coordinates": _square(0, 0)},
+                        {
+                            "type": "MultiPolygon",
+                            "coordinates": [_square(1, 1), _square(2, 2)],
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+    out = split_multipart_geojson(fc)
+    feats = out["features"]
+
+    # Polygon + MultiPolygon(2 parts) -> 3 single polygons, all inheriting external_id
+    assert len(feats) == 3
+    assert all(f["geometry"]["type"] == "Polygon" for f in feats)
+    assert all(f["properties"]["external_id"] == "C" for f in feats)
+
+
+def test_z_coordinates_are_stripped():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": _square(0, 0, z=100)},
+            }
+        ],
+    }
+    out = split_multipart_geojson(fc)
+    ring = out["features"][0]["geometry"]["coordinates"][0]
+    assert all(len(coord) == 2 for coord in ring)
+
+
+def test_part_index_is_opt_in():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"external_id": "B"},
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [_square(0, 0), _square(2, 2)],
+                },
+            }
+        ],
+    }
+    out = split_multipart_geojson(fc, add_part_index=True)
+    assert [f["properties"]["part_index"] for f in out["features"]] == [1, 2]
+
+
+def test_single_part_input_is_unchanged_count():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"external_id": "A"},
+                "geometry": {"type": "Polygon", "coordinates": _square(0, 0)},
+            }
+        ],
+    }
+    out = split_multipart_geojson(fc)
+    assert len(out["features"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# analyze_geojson geometry handling
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_counts_and_flags_geometrycollection():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": _square(0, 0)},
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "GeometryCollection", "geometries": []},
+            },
+        ],
+    }
+    res = analyze_geojson(fc, metrics=["count", "geometry_types"])
+    # GeometryCollection is counted (not silently dropped) and flagged
+    assert res["count"] == 2
+    assert res["geometry_types"].get("GeometryCollection") == 1
+    assert "geometrycollection_warning" in res
+
+
+def test_analyze_fast_check_omits_area_when_not_requested():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": _square(0, 0)},
+            }
+        ],
+    }
+    fast = analyze_geojson(fc, metrics=["count", "geometry_types"])
+    assert set(fast) >= {"count", "geometry_types"}
+    assert "max_area_ha" not in fast and "max_vertices" not in fast
+
+    # When requested, area/vertex metrics are computed
+    full = analyze_geojson(fc, metrics=["max_area_ha", "max_vertices"])
+    assert full["max_area_ha"] > 0
+    assert full["max_vertices"] == 5  # closed unit-square ring


### PR DESCRIPTION
Adds split_multipart_geojson, a pure-python step that splits multipart geometries in the library, restoring what the whisp-app used to do in extractFeatures before the Python rewrite. Run it before analyze_geojson so count already equals the individual-polygon count (resolves the count_individual_polygons TODO in whisp-app service.py). Not wired into the stats pathway; it stays an explicit step the caller runs first.

Split MultiPolygon/MultiPoint into single parts, decompose GeometryCollection, unwrap Feature/FeatureCollection, strip Z; all properties including external_id copied to every part (attribute-identical, no part_index by default)
Speed up analyze_geojson fast checks by only running shapely when an area/vertex metric is requested (count/geometry_types drop from ~256ms to ~1ms on 5000 features)
Count and flag GeometryCollection in analyze_geojson instead of silently dropping it
Fix crs-warning emoji that silently returned empty metrics on Windows consoles
Add tests covering the split behaviour and the analyze_geojson geometry changes
