### PR TITLE
Add ForTy 2020 forest-typology bands (present-but-unused)

### DIFF
--- a/src/openforis_whisp/datasets.py
+++ b/src/openforis_whisp/datasets.py
@@ -181,6 +181,74 @@ def g_jrc_tmf_plantation_prep():
     return plantation_2020.rename("TMF_plant").selfMask()
 
 
+# ForTy (Google Nature Trace + IIASA) forest typology 2020.
+# See https://eartharxiv.org/repository/view/13130. The product stores five class score bands (0-250),
+# band index 0=Primary, 1=NaturallyRegenerating, 2=Planted, 3=Plantation, 4=TreeCrops/Agroforestry,
+# with a residual "other" = 250 - sum. PlantedForest is the weakest class (F1 58.2%), so the
+# planted-vs-plantation split is real but uncertain.
+#
+# Each pixel is assigned its single highest-scoring class via argmax over the five score bands plus the
+# residual "other" (= 250 - sum), giving a mutually-exclusive, exhaustive 1=Primary..5=TreeCrops, 6=Other
+# label (ties resolve to the lowest index, matching the ForTy authors' >= expression). This is the
+# product's intended single-label form. It supersedes the earlier per-band >= 125 threshold: measured
+# over five regions (S Brazil, Amazon, Borneo, Iberia, Congo) the two agreed to 93-100% per class (IoU)
+# and the threshold was already >= 99.9% mutually exclusive, so argmax changes each forest class by only
+# a few percent (mostly the weak Plantation/Planted classes) while guaranteeing the single-label form.
+# See temp_dev_notes/forty_classes_assessment.md.
+#
+# These are PRESENT-BUT-UNUSED output bands: their lookup rows tick no risk pathway
+# (use_for_risk_pcrop/acrop/timber all 0), so they surface ForTy information in the
+# output without affecting any Ind_/risk_ column.
+
+
+def _forty_2020_mean():
+    return ee.ImageCollection(
+        "projects/nature-trace/assets/forest_typology/forest_typology_2020_v1_0_collection"
+    ).mean()
+
+
+def _forty_2020_class():
+    # Argmax over the five class scores plus the residual "other" (= 250 - sum). Returns 1=Primary,
+    # 2=NaturallyRegenerating, 3=Planted, 4=Plantation, 5=TreeCrops/Agroforestry, 6=Other. arrayArgmax
+    # returns the first maximum, so ties resolve to the lowest index (Primary wins), as in the authors'
+    # >= ternary.
+    scores = _forty_2020_mean().select([0, 1, 2, 3, 4])
+    other = scores.reduce(ee.Reducer.sum()).multiply(-1).add(250)
+    return scores.addBands(other).toArray().arrayArgmax().arrayGet([0]).add(1)
+
+
+def _forty_class_present(idx):
+    # idx 0=Primary, 1=NaturallyRegenerating, 2=Planted, 3=Plantation, 4=TreeCrops/Agroforestry;
+    # argmax class label = idx + 1.
+    return _forty_2020_class().eq(idx + 1).selfMask()
+
+
+def g_forty_primary_2020_prep():
+    return _forty_class_present(0).rename("ForTy_primary_2020")
+
+
+def g_forty_nat_reg_2020_prep():
+    return _forty_class_present(1).rename("ForTy_nat_reg_2020")
+
+
+def g_forty_planted_2020_prep():
+    return _forty_class_present(2).rename("ForTy_planted_2020")
+
+
+def g_forty_plantation_2020_prep():
+    return _forty_class_present(3).rename("ForTy_plantation_2020")
+
+
+def g_forty_tree_crops_2020_prep():
+    return _forty_class_present(4).rename("ForTy_tree_crops_2020")
+
+
+def g_forty_forest_2020_prep():
+    # Forest presence = argmax class is one of the four forest classes (1=Primary, 2=NaturallyRegenerating,
+    # 3=Planted, 4=Plantation), i.e. a forest class outscores TreeCrops and "other" at the pixel.
+    return _forty_2020_class().lte(4).selfMask().rename("ForTy_forest_2020")
+
+
 # # Oil_palm_Descals
 # NB updated to Descals et al 2024 paper (as opposed to Descals et al 2021 paper)
 def g_creaf_descals_palm_prep():

--- a/src/openforis_whisp/parameters/lookup_datasets.csv
+++ b/src/openforis_whisp/parameters/lookup_datasets.csv
@@ -237,3 +237,9 @@ nBR_INPE_TCcer_pasture_2020,2190,BR,commodities,NA,1,1,1,0,float32,1,0,nbr_terra
 nBR_MapBiomas_col9_pasture_2020,2200,BR,commodities,NA,1,1,1,0,float32,1,0,nbr_mapbiomasc9_pasture_prep
 nCI_Cocoa_bnetd,2210,CI,commodities,NA,1,1,1,0,float32,1,0,nci_ocs2020_prep
 nCM_Treecover_2020,2220,CM,treecover,NA,1,1,0,0,float32,1,0,ncm_treecover_2020_prep
+ForTy_forest_2020,65,,treecover,NA,0,0,0,0,float32,1,0,g_forty_forest_2020_prep
+ForTy_tree_crops_2020,145,,commodities,NA,0,0,0,0,float32,1,0,g_forty_tree_crops_2020_prep
+ForTy_primary_2020,1825,,NA,primary,0,0,0,0,float32,1,0,g_forty_primary_2020_prep
+ForTy_nat_reg_2020,1835,,NA,naturally_reg_2020,0,0,0,0,float32,1,0,g_forty_nat_reg_2020_prep
+ForTy_planted_2020,1852,,NA,planted_plantation_2020,0,0,0,0,float32,1,0,g_forty_planted_2020_prep
+ForTy_plantation_2020,1854,,NA,planted_plantation_2020,0,0,0,0,float32,1,0,g_forty_plantation_2020_prep

--- a/tests/helpers/test_forty.py
+++ b/tests/helpers/test_forty.py
@@ -1,0 +1,75 @@
+"""ForTy 2020 forest-typology bands: present-but-unused (verdict-neutral) contract.
+
+These bands are emitted as output columns but must NOT feed any risk indicator.
+The tests are pure-Python (no Earth Engine): they check the shipped lookup table
+and the risk-column getters, guarding against anyone silently wiring ForTy into risk.
+"""
+
+import openforis_whisp.datasets as datasets
+from openforis_whisp.risk import (
+    lookup_gee_datasets_df,
+    get_cols_ind_01_treecover,
+    get_cols_ind_02_commodities,
+    get_cols_ind_05_primary_2020,
+    get_cols_ind_06_nat_reg_2020,
+    get_cols_ind_07_planted_2020,
+)
+
+# name -> prep function expected in datasets.py (the CSV/code contract)
+FORTY_EXPECTED = {
+    "ForTy_primary_2020": "g_forty_primary_2020_prep",
+    "ForTy_nat_reg_2020": "g_forty_nat_reg_2020_prep",
+    "ForTy_planted_2020": "g_forty_planted_2020_prep",
+    "ForTy_plantation_2020": "g_forty_plantation_2020_prep",
+    "ForTy_tree_crops_2020": "g_forty_tree_crops_2020_prep",
+    "ForTy_forest_2020": "g_forty_forest_2020_prep",
+}
+
+
+def _forty_rows(df):
+    return df[df["name"].astype(str).str.startswith("ForTy_")]
+
+
+def test_forty_lookup_rows_are_risk_neutral():
+    """Every ForTy band ticks no risk pathway yet is still emitted."""
+    rows = _forty_rows(lookup_gee_datasets_df)
+    assert not rows.empty, "no ForTy_ rows found in the lookup table"
+    for col in ("use_for_risk_pcrop", "use_for_risk_acrop", "use_for_risk_timber"):
+        assert (rows[col] == 0).all(), (
+            f"ForTy rows must have {col}==0 (present-but-unused); "
+            f"offenders: {list(rows.loc[rows[col] != 0, 'name'])}"
+        )
+    assert (
+        rows["exclude_from_output"] == 0
+    ).all(), "ForTy rows must be emitted (exclude_from_output==0)"
+
+
+def test_forty_bands_excluded_from_every_indicator():
+    """No ForTy band is selected by any risk-indicator getter."""
+    df = lookup_gee_datasets_df
+    selected = []
+    for risk_col in ("use_for_risk_pcrop", "use_for_risk_acrop"):
+        selected += get_cols_ind_01_treecover(df, risk_col=risk_col)
+        selected += get_cols_ind_02_commodities(df, risk_col=risk_col)
+    selected += get_cols_ind_05_primary_2020(df)
+    selected += get_cols_ind_06_nat_reg_2020(df)
+    selected += get_cols_ind_07_planted_2020(df)
+    forty = sorted(c for c in selected if str(c).startswith("ForTy_"))
+    assert forty == [], f"ForTy bands must not feed any indicator, got: {forty}"
+
+
+def test_forty_prep_functions_present_and_named():
+    """Each ForTy lookup row maps to a real prep function of the expected name."""
+    rows = _forty_rows(lookup_gee_datasets_df)
+    names = set(rows["name"])
+    missing = set(FORTY_EXPECTED) - names
+    assert not missing, f"missing ForTy lookup rows: {sorted(missing)}"
+
+    mapping = dict(zip(rows["name"], rows["corresponding_variable"]))
+    for name, fn in FORTY_EXPECTED.items():
+        assert (
+            mapping.get(name) == fn
+        ), f"{name} corresponding_variable is {mapping.get(name)!r}, expected {fn!r}"
+        assert hasattr(datasets, fn) and callable(
+            getattr(datasets, fn)
+        ), f"prep function {fn} not found/callable in datasets.py"


### PR DESCRIPTION
Adds the ForTy (Google Nature Trace + IIASA) 2020 forest-typology product as six output bands, assigned by mutually-exclusive argmax over the class scores: primary, naturally regenerating, planted, plantation, tree crops, and a grouped forest class. They are present-but-unused (use_for_risk_pcrop/acrop/timber all 0), so they ship as informational output columns and change no Ind_ or risk_ result. Ordered into the existing theme groups, using only existing theme_timber values.

Adds tests/helpers/test_forty.py guarding that the ForTy rows stay risk-neutral and never feed an indicator.

Addresses #213.