### PR TITLE
Bump version to 3.0.0a15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "openforis-whisp"
-version = "3.0.0a14"
+version = "3.0.0a15"
 description = "Whisp (What is in that plot) is an open-source solution which helps to produce relevant forest monitoring information and support compliance with deforestation-related regulations."
 repository = "https://github.com/forestdatapartnership/whisp"
 authors = ["Andy Arnell <andrew.arnell@fao.org>"]


### PR DESCRIPTION
Release 3.0.0a15. Since a14: Brazil PRODES before-2020 layer to the Dec-2020 cutoff (#221), split_multipart_geojson plus analyze_geojson fixes (#243), ForTy 2020 forest-typology output bands (#244, closes #213), lookup-table merge with pcrop/acrop split, and whisp_columns.xlsx removal with docs repointed to the hosted result fields reference (#245).